### PR TITLE
Changes to MainAcitivty and CustomAdapter

### DIFF
--- a/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
+++ b/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
@@ -10,7 +10,7 @@ class CustomAdapter(private val names: List<String>, private val context: Contex
 
     // How many items are in the collection
     override fun getCount(): Int {
-        return 5
+        return names.size
     }
 
     // Fetch an item from the collection

--- a/app/src/main/java/edu/temple/namelist/MainActivity.kt
+++ b/app/src/main/java/edu/temple/namelist/MainActivity.kt
@@ -9,6 +9,7 @@ import android.widget.BaseAdapter
 import android.widget.Button
 import android.widget.Spinner
 import android.widget.TextView
+import androidx.core.view.isEmpty
 
 class MainActivity : AppCompatActivity() {
 
@@ -38,6 +39,13 @@ class MainActivity : AppCompatActivity() {
 
         findViewById<View>(R.id.deleteButton).setOnClickListener {
             (names as MutableList).removeAt(spinner.selectedItemPosition)
+            nameTextView.text =
+                if (spinner.selectedItemPosition == names.size){
+                    (names as MutableList)[spinner.selectedItemPosition - 1]
+                }
+                else{
+                    (names as MutableList)[spinner.selectedItemPosition]
+                }
             (spinner.adapter as BaseAdapter).notifyDataSetChanged()
         }
 


### PR DESCRIPTION
In the CustomAdapter, the bug that prevents deleting the names is the function getCount(). I fixed this by changing the fixed number to the size of the list.

After the bug was fixed, it can delete the selected name from the spinner, but now a different name has appeared, while still showing the deleted name. Also, if the name was the last item in the list that was going to be deleted, the app would crash. To fix this, in the OnClickListener in the Main Activity, I set up an if-else statement, showing if the item position was the size of names, and set the text to the item position - 1. Else, set the name to the current item position.