### PR TITLE
Fixed app crash when deleting a name from spinner.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
+++ b/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
@@ -10,7 +10,7 @@ class CustomAdapter(private val names: List<String>, private val context: Contex
 
     // How many items are in the collection
     override fun getCount(): Int {
-        return 5
+        return names.size
     }
 
     // Fetch an item from the collection

--- a/app/src/main/java/edu/temple/namelist/MainActivity.kt
+++ b/app/src/main/java/edu/temple/namelist/MainActivity.kt
@@ -12,7 +12,7 @@ import android.widget.TextView
 
 class MainActivity : AppCompatActivity() {
 
-    lateinit var names: List<String>
+    lateinit var names: MutableList<String>
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)


### PR DESCRIPTION
Fixed app crash when selecting a new name after deleting one.
- `MutableList` used instead of `List` for safe deletion.
- `notifyDataSetChanged()` properly updates adapter.
- Prevented invalid index access in Spinner selection.
