### PR TITLE
Fix delete button crashes

### DIFF
--- a/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
+++ b/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
@@ -10,7 +10,7 @@ class CustomAdapter(private val names: List<String>, private val context: Contex
 
     // How many items are in the collection
     override fun getCount(): Int {
-        return 5
+        return names.size
     }
 
     // Fetch an item from the collection

--- a/app/src/main/java/edu/temple/namelist/MainActivity.kt
+++ b/app/src/main/java/edu/temple/namelist/MainActivity.kt
@@ -37,8 +37,13 @@ class MainActivity : AppCompatActivity() {
         }
 
         findViewById<View>(R.id.deleteButton).setOnClickListener {
-            (names as MutableList).removeAt(spinner.selectedItemPosition)
-            (spinner.adapter as BaseAdapter).notifyDataSetChanged()
+            if (names.isNotEmpty()) {
+                (names as MutableList).removeAt(spinner.selectedItemPosition)
+                (spinner.adapter as BaseAdapter).notifyDataSetChanged()
+                if (names.isEmpty()) {
+                    nameTextView.text = ""
+                }
+            }
         }
 
     }


### PR DESCRIPTION
## Summary
- **Bug 1 – Hardcoded `getCount()`:** `CustomAdapter.getCount()` was always returning `5` instead of `names.size`. After deleting a name the adapter still thought there were 5 items, so it tried to access indices that didn't exist anymore and threw an `IndexOutOfBoundsException`. Fixed it by returning `names.size` instead.
- **Bug 2 – No empty-list guard on delete:** If you deleted all the names and hit delete again, the app crashed because `removeAt()` was called on an empty list. Added an `isNotEmpty()` check before removing, and also clear the text view when the list is empty.