### PR TITLE
lab activity 5

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
+++ b/app/src/main/java/edu/temple/namelist/CustomAdapter.kt
@@ -10,7 +10,7 @@ class CustomAdapter(private val names: List<String>, private val context: Contex
 
     // How many items are in the collection
     override fun getCount(): Int {
-        return 5
+        return names.size
     }
 
     // Fetch an item from the collection

--- a/app/src/main/java/edu/temple/namelist/MainActivity.kt
+++ b/app/src/main/java/edu/temple/namelist/MainActivity.kt
@@ -21,6 +21,7 @@ class MainActivity : AppCompatActivity() {
 
         val spinner = findViewById<Spinner>(R.id.spinner)
         val nameTextView = findViewById<TextView>(R.id.textView)
+        val deleteButton = findViewById<Button>(R.id.deleteButton)
 
         with (spinner) {
             adapter = CustomAdapter(names, this@MainActivity)
@@ -36,9 +37,23 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        findViewById<View>(R.id.deleteButton).setOnClickListener {
-            (names as MutableList).removeAt(spinner.selectedItemPosition)
+        deleteButton.setOnClickListener {
+            // (names as MutableList).removeAt(spinner.selectedItemPosition)
+            // (spinner.adapter as BaseAdapter).notifyDataSetChanged()
+            val oldPos = spinner.selectedItemPosition
+
+            (names as MutableList).removeAt(oldPos)
             (spinner.adapter as BaseAdapter).notifyDataSetChanged()
+
+            if (names.isNotEmpty()) {
+                val newPos = oldPos.coerceAtMost(names.lastIndex)
+                spinner.setSelection(newPos, false)
+                nameTextView.text = names[newPos]
+            } else {
+                nameTextView.text = ""
+                deleteButton.isEnabled = false
+            }
+
         }
 
     }


### PR DESCRIPTION
I tackled two main issues that were causing the app to crash or behave unexpectedly.\
1.
Incorrect Item Count: The first bug was in the CustomAdapter. The adapter was hardcoded to always report that it had 5 items, even after you deleted one. When you tried to select a name after a deletion, the app would crash because it was trying to access data that wasn't there anymore. I fixed this by making the adapter report the actual size of your name list.
2.
Deleting from an Empty List: The second issue was in the main screen's logic. The app would crash if you tried to delete a name when the list was already empty and I added a simple check to make sure the app only tries to delete a name if there are names in the list to begin with. I also made sure that when you delete the last name, the text on the screen clears out, so it doesn't keep showing a name that's been removefd